### PR TITLE
Fixed bug I realized existed in the shower

### DIFF
--- a/src/simulation/sim_physics_engine.rs
+++ b/src/simulation/sim_physics_engine.rs
@@ -148,12 +148,12 @@ fn calculate_cell_divergence(
 		to index like this. */
 	let left_velocity: f32	= grid.velocity_u[cell_row][cell_col];
 	let right_velocity: f32	= grid.velocity_u[cell_row][cell_col + 1];
-	let up_velocity: f32	= grid.velocity_v[cell_row][cell_col];
-	let down_velocity: f32	= grid.velocity_v[cell_row + 1][cell_col];
+	let up_velocity: f32	= grid.velocity_v[cell_row + 1][cell_col];
+	let down_velocity: f32	= grid.velocity_v[cell_row][cell_col];
 	
 	// BUG: The up and down flows may need to be reversed.
 	let x_divergence: f32	= right_velocity - left_velocity;
-	let y_divergence: f32	= down_velocity - up_velocity;
+	let y_divergence: f32	= up_velocity - down_velocity;
 	let divergence: f32		= overrelaxation * (x_divergence + y_divergence);
 	divergence
 }

--- a/src/simulation/sim_state_manager.rs
+++ b/src/simulation/sim_state_manager.rs
@@ -29,6 +29,8 @@ fn setup(
 	mut grid:			ResMut<SimGrid>) {
 
 	let test_particle = add_particle(&mut commands, Vec2::ZERO, Vec2::ZERO);
+	grid.velocity_u[10][15] = 7.0;
+	grid.velocity_v[10][15] = 7.0;
 	// TODO: Get saved simulation data from most recently open file OR default file.
 	// TODO: Population constraints, grid, and particles with loaded data.
 }
@@ -206,11 +208,12 @@ impl SimGrid {
 		coordinates.** */
 	pub fn get_cell_coordinates_from_position(&self, position: &Vec2) -> Vec2 {
 		
-		let cell_size: f32 = self.cell_size as f32;
+		let cell_size: f32			= self.cell_size as f32;
+		let grid_upper_bound: f32	= self.dimensions.0 as f32 * cell_size;
 		
 		let coordinates: Vec2 = Vec2 {
-			x: position[1] / cell_size,
-			y: position[0] / cell_size,
+			x: (grid_upper_bound - position[1]) / cell_size,	// Row
+			y: position[0] / cell_size,							// Column
 		};
 		
 		coordinates

--- a/src/simulation/sim_state_manager.rs
+++ b/src/simulation/sim_state_manager.rs
@@ -29,8 +29,6 @@ fn setup(
 	mut grid:			ResMut<SimGrid>) {
 
 	let test_particle = add_particle(&mut commands, Vec2::ZERO, Vec2::ZERO);
-	grid.velocity_u[10][15] = 7.0;
-	grid.velocity_v[10][15] = 7.0;
 	// TODO: Get saved simulation data from most recently open file OR default file.
 	// TODO: Population constraints, grid, and particles with loaded data.
 }


### PR DESCRIPTION
- Fixed a bug where the retrieved cell coordinate is actually the "inverse" of the true cell coordinate in get_cell_coordinates_from_position().  This also related to a but in the incompressibility formula which created odd curl behavior in areas of low velocity.