### PR TITLE
Juice-65: clone_grid_velocities(), add_particles_in_radius(), construct_test_simulation_layout()

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,4 +12,7 @@ pub enum Error {
 	
 	#[error("Out of grid bounds: `{0}`")]
 	OutOfGridBounds(&'static str),
+	
+	#[error("Invalid cell to create particles: `{0}`")]
+	InvalidCellParticleCreation(&'static str),
 }

--- a/src/juice_renderer.rs
+++ b/src/juice_renderer.rs
@@ -197,19 +197,19 @@ fn color_particles(mut particles: Query<(&SimParticle, &mut Sprite)>, color: Col
 /// Draw the solid grid cells within the grid.
 fn draw_grid_solids(grid: Res<SimGrid>, grid_render_data: Res<GridRenderData>, mut gizmos: Gizmos) {
 
+	// For each column in each row, determine each cell's type.
 	for row in 0..grid.dimensions.0 {
 		for col in 0..grid.dimensions.1 {
 			
 			match grid.cell_type[row as usize][col as usize] {
-				SimGridCellType::Fluid	=> continue,
-				SimGridCellType::Air	=> continue,
-				SimGridCellType::Solid	=> draw_solid_cell(
+				SimGridCellType::Fluid	=> continue,			// Do nothing if fluid.
+				SimGridCellType::Air	=> continue,			// Do nothing if air.
+				SimGridCellType::Solid	=> draw_solid_cell(		// Draw something if solid.
 					grid.as_ref(),
 					Vec2 { x: row as f32, y: col as f32 },
 					grid_render_data.solid_cell_color,
 					&mut gizmos
 				),
-				_						=> continue,
 			}
 		}
 	}

--- a/src/juice_renderer.rs
+++ b/src/juice_renderer.rs
@@ -119,7 +119,7 @@ fn update_particle_position(mut particles: Query<(&SimParticle, &mut Transform)>
 fn update_particle_size(mut particles: Query<(&SimParticle, &mut Sprite)>) {
 	
 	for (_, mut sprite) in particles.iter_mut() {
-		let size: f32 = 10.0;
+		let size: f32 = 1.0;
 		sprite.custom_size = Some(Vec2::splat(size));
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod simulation;
 mod util;
 mod juice_renderer;
 mod error;
+mod test;
 
 use simulation::sim_state_manager;
 use simulation::sim_physics_engine;

--- a/src/simulation/sim_state_manager.rs
+++ b/src/simulation/sim_state_manager.rs
@@ -3,7 +3,8 @@ use std::f32::consts::{PI, FRAC_2_PI, FRAC_PI_2, E, LOG2_E};
 use bevy::prelude::*;
 use bevy::math::Vec2;
 use crate::error::Error;
-use crate::{juice_renderer};
+use crate::juice_renderer;
+use crate::test;
 
 use super::sim_physics_engine::{
 	particles_to_grid,
@@ -27,21 +28,10 @@ impl Plugin for SimStateManager {
 /// Simulation state manager initialization.
 fn setup(
 	mut commands:		Commands,
-	mut _constraints:	ResMut<SimConstraints>,
+	mut constraints:	ResMut<SimConstraints>,
 	mut grid:			ResMut<SimGrid>) {
 	
-	let grid_center: Vec2 = Vec2 {
-		x: (grid.dimensions.1 * grid.cell_size) as f32 * 0.5,
-		y: (grid.dimensions.0 * grid.cell_size) as f32 * 0.5,
-	};
-	let _test_particles = add_particles_in_radius(
-		&mut commands,
-		grid.as_ref(),
-		3.5,
-		100.0,
-		Vec2 { x: grid_center[0], y: grid_center[1] },
-		Vec2::ZERO
-	);
+	test::construct_test_simulation_layout(grid.as_mut(), commands);
 	// TODO: Get saved simulation data from most recently open file OR default file.
 	// TODO: Population constraints, grid, and particles with loaded data.
 }
@@ -245,7 +235,7 @@ pub struct SimParticle {
 
 /** Add many particles into the simulation within a radius.  Note that particle_density is 
 	the number of particles per unit radius. */
-fn add_particles_in_radius(
+pub fn add_particles_in_radius(
 	commands:			&mut Commands,
 	grid:				&SimGrid,
 	particle_density:	f32,

--- a/src/simulation/sim_state_manager.rs
+++ b/src/simulation/sim_state_manager.rs
@@ -91,7 +91,7 @@ impl SimConstraints {
 	}
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum SimGridCellType {
 	Solid,
     Fluid,
@@ -281,13 +281,18 @@ fn add_particle(
 	velocity:		Vec2) -> Result<()> {
 	
 	// Don't allow the user to create particles out of the simulation grid's bounds!
-	if position[0] < 0.0 || position[0] > (grid.dimensions.1 * grid.cell_size) as f32
-	{
+	if position[0] < 0.0 || position[0] > (grid.dimensions.1 * grid.cell_size) as f32 {
 		return Err(Error::OutOfGridBounds("X-coordinate for particle creation is out of grid bounds!"));
 	}
-	if position[1] < 0.0 || position[1] > (grid.dimensions.0 * grid.cell_size) as f32
-	{
+	if position[1] < 0.0 || position[1] > (grid.dimensions.0 * grid.cell_size) as f32 {
 		return Err(Error::OutOfGridBounds("Y-coordinate for particle creation is out of grid bounds!"));
+	}
+	// If the cell we are inside of is a solid, don't create the particle!
+	let cell_coordinates: Vec2 = grid.get_cell_coordinates_from_position(&position);
+	if matches!(
+		grid.cell_type[cell_coordinates[0] as usize][cell_coordinates[1] as usize],
+		SimGridCellType::Solid) {
+		return Err(Error::InvalidCellParticleCreation("Chosen cell is solid!"));
 	}
 	
 	let particle: Entity = commands.spawn(

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,8 +8,18 @@ use crate::simulation::sim_state_manager::{
 };
 use crate::juice_renderer::draw_vector_arrow;
 
+/// Create a simulation layout for testing.
 pub fn construct_test_simulation_layout(grid: &mut SimGrid, mut commands: Commands)
 {
+	// Create a bunch of solid cells.
+	grid.cell_type[19][12] = SimGridCellType::Solid;
+	grid.cell_type[20][12] = SimGridCellType::Solid;
+	grid.cell_type[20][13] = SimGridCellType::Solid;
+	grid.cell_type[20][14] = SimGridCellType::Solid;
+	grid.cell_type[20][15] = SimGridCellType::Solid;
+	grid.cell_type[19][15] = SimGridCellType::Solid;
+	
+	// Spawn a group of particles at the center of the screen.
 	let grid_center: Vec2 = Vec2 {
 		x: (grid.dimensions.1 * grid.cell_size) as f32 * 0.5,
 		y: (grid.dimensions.0 * grid.cell_size) as f32 * 0.5,
@@ -22,12 +32,26 @@ pub fn construct_test_simulation_layout(grid: &mut SimGrid, mut commands: Comman
 		Vec2 { x: grid_center[0], y: grid_center[1] },
 		Vec2::ZERO
 	);
-	grid.cell_type[19][12] = SimGridCellType::Solid;
-	grid.cell_type[20][12] = SimGridCellType::Solid;
-	grid.cell_type[20][13] = SimGridCellType::Solid;
-	grid.cell_type[20][14] = SimGridCellType::Solid;
-	grid.cell_type[20][15] = SimGridCellType::Solid;
-	grid.cell_type[19][15] = SimGridCellType::Solid;
+	
+	/*// Spawn more particles to test spawning inside solids is rejected.
+	let _moar_test_particles = add_particles_in_radius(
+		&mut commands,
+		grid,
+		2.35,
+		50.0,
+		Vec2 { x: 140.0, y: 45.0 },
+		Vec2::ZERO
+	);
+	
+	// Spawn even MOAR particles to test spawning inside solids is rejected.  ~~UwU~~
+	let _moar_test_particles = add_particles_in_radius(
+		&mut commands,
+		grid,
+		10.0,
+		20.0,
+		Vec2 { x: 100.0, y: 100.0 },
+		Vec2::ZERO
+	);*/
 }
 
 pub fn test_draw_vector_arrow(time: Res<Time>, gizmos: &mut Gizmos) {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,9 +1,37 @@
 use bevy::{
 	prelude::*,
 };
+use crate::simulation::sim_state_manager::{
+	SimGridCellType,
+	SimGrid,
+	add_particles_in_radius
+};
+use crate::juice_renderer::draw_vector_arrow;
 
-pub fn test_draw_vector_arrow(time: Res<Time>) {
+pub fn construct_test_simulation_layout(grid: &mut SimGrid, mut commands: Commands)
+{
+	let grid_center: Vec2 = Vec2 {
+		x: (grid.dimensions.1 * grid.cell_size) as f32 * 0.5,
+		y: (grid.dimensions.0 * grid.cell_size) as f32 * 0.5,
+	};
+	let _test_particles = add_particles_in_radius(
+		&mut commands,
+		grid,
+		3.5,
+		100.0,
+		Vec2 { x: grid_center[0], y: grid_center[1] },
+		Vec2::ZERO
+	);
+	grid.cell_type[19][12] = SimGridCellType::Solid;
+	grid.cell_type[20][12] = SimGridCellType::Solid;
+	grid.cell_type[20][13] = SimGridCellType::Solid;
+	grid.cell_type[20][14] = SimGridCellType::Solid;
+	grid.cell_type[20][15] = SimGridCellType::Solid;
+	grid.cell_type[19][15] = SimGridCellType::Solid;
+}
+
+pub fn test_draw_vector_arrow(time: Res<Time>, gizmos: &mut Gizmos) {
 	let dir: f32 = time.elapsed().as_secs_f32() * 16.0;
 	let mag: f32 = (time.elapsed().as_secs_f32().sin() + 1.1) * 100.0;
-	draw_vector_arrow(Vec2::ZERO, dir, mag, &mut gizmos);
+	draw_vector_arrow(Vec2::ZERO, dir, mag, Color::PINK, gizmos);
 }


### PR DESCRIPTION
- Implemented clone_grid_velocities()
- Implemented add_particles_in_radius()
        - Particles spawn (mostly) evenly spaced within a radius!  You can specify position, radius, and density to suit your needs.
- Implemented construct_test_simulation_layout()
        - The commented lines should get uncommented when we are ready to bugcheck our simulation math.